### PR TITLE
ember-data-factory-guy error with Ember 2.10.0

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.RESTAdapter.extend({
+  namespace: 'api/1'
+});

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  body: DS.attr()
+});

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  comments: DS.hasMany('comment')
+});

--- a/app/serializers/comment.js
+++ b/app/serializers/comment.js
@@ -1,0 +1,4 @@
+import DS from 'ember-data';
+
+//NOTE: there is no error when `DS.EmbeddedRecordsMixin` is removed
+export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin);

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,9 @@
 {
   "name": "glammer",
   "dependencies": {
-    "ember": "beta",
+    "ember": "2.10.0",
     "ember-cli-shims": "0.1.1",
-    "ember-qunit-notifications": "0.1.0"
+    "ember-qunit-notifications": "0.1.0",
+    "jquery-mockjax": "2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.7.0",
+    "ember-data-factory-guy": "2.9.3",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.7.0",
+    "ember-data": "2.10.0",
     "ember-data-factory-guy": "2.9.3",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,0 +1,25 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'glammer/tests/helpers/module-for-acceptance';
+import { mockSetup, mockTeardown, build } from 'ember-data-factory-guy';
+
+moduleForAcceptance('Acceptance | index', {
+  beforeEach() {
+    mockSetup();
+  },
+  afterEach() {
+    mockTeardown();
+  }
+});
+
+test('visiting /index', function(assert) {
+  let post = build('post', {
+    comments: []
+  });
+
+  console.log('GJ: ', post);
+  visit('/issue1');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/issue1');
+  });
+});

--- a/tests/factories/comment.js
+++ b/tests/factories/comment.js
@@ -1,0 +1,7 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('comment', {
+  default: {
+    body: 'this is a comment'
+  }
+});

--- a/tests/factories/post.js
+++ b/tests/factories/post.js
@@ -1,0 +1,7 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('post', {
+  default: {
+    comments: FactoryGuy.hasMany('comments', 1)
+  }
+});


### PR DESCRIPTION
http://localhost:4201/tests?hidepassed

**Ember 2.9.0:**

<img width="847" alt="screen shot 2016-11-29 at 12 41 18" src="https://cloud.githubusercontent.com/assets/2526/20710271/6c575382-b631-11e6-9e66-7de6bcea0427.png">

**Ember 2.10.0:**

<img width="909" alt="screen shot 2016-11-29 at 12 41 43" src="https://cloud.githubusercontent.com/assets/2526/20710275/70c0649a-b631-11e6-9778-f4414b8dd8aa.png">
